### PR TITLE
Fix boost_test_jamfile to skip comment lines in Jamfiles

### DIFF
--- a/include/BoostTestJamfile.cmake
+++ b/include/BoostTestJamfile.cmake
@@ -46,9 +46,10 @@ function(boost_test_jamfile)
   foreach(line IN LISTS data)
     if(line)
 
+      string(REGEX MATCH "^#.+" is_comment ${line})
       string(REGEX MATCHALL "[^ ]+" ll ${line})
 
-      if(ll)
+      if(ll AND NOT is_comment)
         list(GET ll 0 e0)
 
         if(e0 IN_LIST types)


### PR DESCRIPTION
Otherwise, the function generates targets for commented invocations
of run, compile, etc. rules.