### PR TITLE
Add BoostLibraryIncludes.cmake module for generating library includes

### DIFF
--- a/include/BoostLibraryIncludes.cmake
+++ b/include/BoostLibraryIncludes.cmake
@@ -1,0 +1,34 @@
+# Copyright 2022 Andrey Semashev
+#
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# After including this module, BOOST_LIBRARY_INCLUDES variable is set to the list of include
+# directories for all Boost libraries. If the monolithic include directory is found, it is
+# used instead.
+
+if (NOT CMAKE_VERSION VERSION_LESS 3.10)
+    include_guard()
+endif()
+
+# Generates a list of include paths for all Boost libraries in \a result variable. Uses unified Boost include tree, if available.
+function(generate_boost_include_paths result)
+    if (IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../../../boost" AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../../boost/version.hpp")
+        get_filename_component(include_dir "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+        set(${result} "${include_dir}" CACHE INTERNAL "Boost libraries includes")
+        return()
+    endif()
+    file(GLOB path_list LIST_DIRECTORIES True "${CMAKE_CURRENT_LIST_DIR}/../../../libs/*")
+    foreach(path IN LISTS path_list)
+        if (IS_DIRECTORY "${path}/include")
+            get_filename_component(include_dir "${path}/include" ABSOLUTE)
+            list(APPEND include_list "${include_dir}")
+        endif()
+    endforeach()
+    set(${result} ${include_list} CACHE INTERNAL "Boost libraries includes")
+endfunction()
+
+if (NOT DEFINED BOOST_LIBRARY_INCLUDES)
+    generate_boost_include_paths(BOOST_LIBRARY_INCLUDES)
+    # message(STATUS "Boost library includes: ${BOOST_LIBRARY_INCLUDES}")
+endif()


### PR DESCRIPTION
This module sets `BOOST_LIBRARY_INCLUDES` variable to the list of all library includes. The module detects the monolithic include directory, which is present in the official monolithic Boost distribution and after `b2 headers`, and returns it instead when present.

This module is useful when implementing CMake configuration checks that rely on Boost libraries. Configuration checks cannot use CMake targets defined by libraries because at the point of configuration these targets are not yet defined.

This module basically extracts the duplicate code that is present in multiple Boost libraries I maintain. Once it's merged, I will be able to switch these libraries to this common implementation. Plus, this will avoid scanning the filesystem multiple times, slightly reducing configuration time.
