### PR TITLE
Add dependency of check-target on tests-target

### DIFF
--- a/include/BoostTest.cmake
+++ b/include/BoostTest.cmake
@@ -139,6 +139,9 @@ function(boost_test)
 
   if(NOT TARGET tests)
     add_custom_target(tests)
+    if(TARGET check)
+      add_dependencies(check tests)
+    endif()
   endif()
 
   if(__TYPE STREQUAL "compile")


### PR DESCRIPTION
This allows to build and run the tests by building (only) the `check` target

The `check` target is created at https://github.com/boostorg/cmake/blob/bd981bfaff20ae4275ecbeba711c90e7fc9d0316/include/BoostRoot.cmake#L52

CC @pdimov 