### PR TITLE
Generate test name ignoring file extension

### DIFF
--- a/include/BoostTest.cmake
+++ b/include/BoostTest.cmake
@@ -60,6 +60,7 @@ function(boost_test)
 
   if(NOT __NAME)
     list(GET __SOURCES 0 __NAME)
+    get_filename_component(__NAME ${__NAME} NAME_WE)
     string(MAKE_C_IDENTIFIER ${__NAME} __NAME)
   endif()
 


### PR DESCRIPTION
The test names are overly verbose containing a `_cpp` suffix.
Remove that.

A `grep -r --include 'CMakeLists.txt' _cpp` in the boost root shows nothing which relies on that.