### PR TITLE
Print CMake version on VERBOSE configure

### DIFF
--- a/include/BoostRoot.cmake
+++ b/include/BoostRoot.cmake
@@ -11,6 +11,7 @@ endif()
 include(BoostMessage)
 include(BoostInstall)
 
+boost_message(VERBOSE "Using CMake ${CMAKE_VERSION}")
 #
 
 set(__boost_incompatible_libraries "")


### PR DESCRIPTION
As CMake changes behavior or available features depending on the version it is useful to know the version actually used during a configure run.