### PR TITLE
BoostTestJamfile: Allow multiple sources for tests

### DIFF
--- a/include/BoostTestJamfile.cmake
+++ b/include/BoostTestJamfile.cmake
@@ -48,11 +48,14 @@ function(boost_test_jamfile)
   set(types "compile|compile-fail|link|link-fail|run|run-fail")
 
   foreach(line IN LISTS data)
-
-    if(line MATCHES "^[ \t]*(${types})[ \t]+([^ \t]+)[ \t]*(\;[ \t]*)?$")
+    # Match something like 'run foo.c ;' (single source, any name) or 'run foo.cpp bar.cpp ;' (multiple sources, restricted names)
+    # Also allow missing semicolon at the line end to support e.g. 'run mytest.cpp\n : : : something ;' (ignore 'something')
+    if(line MATCHES "^[ \t]*(${types})[ \t]+([^ \t]+|([a-zA-Z0-9_]+\.cpp[ \t]+)+)[ \t]*(;[ \t]*)?$")
+      # Convert the space separated list of sources (2nd case) into CMake list of sources. No-op for single source
+      string(REPLACE ".cpp " ".cpp;" sources "${CMAKE_MATCH_2}")
 
       boost_test(PREFIX "${__PREFIX}" TYPE "${CMAKE_MATCH_1}"
-        SOURCES "${CMAKE_MATCH_2}"
+        SOURCES ${sources}
         LINK_LIBRARIES ${__LIBRARIES} ${__LINK_LIBRARIES}
         COMPILE_DEFINITIONS ${__COMPILE_DEFINITIONS}
         COMPILE_OPTIONS ${__COMPILE_OPTIONS}

--- a/include/BoostTestJamfile.cmake
+++ b/include/BoostTestJamfile.cmake
@@ -51,17 +51,18 @@ function(boost_test_jamfile)
     # Extract type and remaining part, (silently) ignore any other line
     if(line MATCHES "^[ \t]*(${types})([ \t].*|$)")
       set(type ${CMAKE_MATCH_1})
-      set(args ${CMAKE_MATCH_2})
+      set(args ${CMAKE_MATCH_2}) # This starts with a space
 
       if(args MATCHES "^[ \t]+([^ \t]+)[ \t]*(;[ \t]*)?$")
         # Single source, e.g. 'run foo.c ;'
         # Semicolon is optional to support e.g. 'run mytest.cpp\n : : : something ;' (ignore 'something')
         set(sources ${CMAKE_MATCH_1})
-      elseif(args MATCHES "^[ \t]+(([a-zA-Z0-9_]+\.cpp[ \t]+)+)(;[ \t]*)?$")
+      elseif(args MATCHES "^(([ \t]+[a-zA-Z0-9_]+\.cpp)+)[ \t]*(;[ \t]*)?$")
         # Multiple sources with restricted names to avoid false positives, e.g. 'run foo.cpp bar.cpp ;'
         # Again with optional semicolon
+        string(STRIP "${CMAKE_MATCH_1}" sources)
         # Convert space-separated list into CMake list
-        string(REGEX REPLACE "\.cpp[ \t]+" ".cpp;" sources "${CMAKE_MATCH_1}")
+        string(REGEX REPLACE "\.cpp[ \t]+" ".cpp;" sources "${sources}")
       else()
         boost_message(VERBOSE "boost_test_jamfile: Jamfile line ignored: ${line}")
         continue()

--- a/include/BoostTestJamfile.cmake
+++ b/include/BoostTestJamfile.cmake
@@ -48,24 +48,32 @@ function(boost_test_jamfile)
   set(types "compile|compile-fail|link|link-fail|run|run-fail")
 
   foreach(line IN LISTS data)
-    # Match something like 'run foo.c ;' (single source, any name) or 'run foo.cpp bar.cpp ;' (multiple sources, restricted names)
-    # Also allow missing semicolon at the line end to support e.g. 'run mytest.cpp\n : : : something ;' (ignore 'something')
-    if(line MATCHES "^[ \t]*(${types})[ \t]+([^ \t]+|([a-zA-Z0-9_]+\.cpp[ \t]+)+)[ \t]*(;[ \t]*)?$")
-      # Convert the space separated list of sources (2nd case) into CMake list of sources. No-op for single source
-      string(REPLACE ".cpp " ".cpp;" sources "${CMAKE_MATCH_2}")
+    # Extract type and remaining part, (silently) ignore any other line
+    if(line MATCHES "^[ \t]*(${types})([ \t].*|$)")
+      set(type ${CMAKE_MATCH_1})
+      set(args ${CMAKE_MATCH_2})
 
-      boost_test(PREFIX "${__PREFIX}" TYPE "${CMAKE_MATCH_1}"
+      if(args MATCHES "^[ \t]+([^ \t]+)[ \t]*(;[ \t]*)?$")
+        # Single source, e.g. 'run foo.c ;'
+        # Semicolon is optional to support e.g. 'run mytest.cpp\n : : : something ;' (ignore 'something')
+        set(sources ${CMAKE_MATCH_1})
+      elseif(args MATCHES "^[ \t]+(([a-zA-Z0-9_]+\.cpp[ \t]+)+)(;[ \t]*)?$")
+        # Multiple sources with restricted names to avoid false positives, e.g. 'run foo.cpp bar.cpp ;'
+        # Again with optional semicolon
+        # Convert space-separated list into CMake list
+        string(REGEX REPLACE "\.cpp[ \t]+" ".cpp;" sources "${CMAKE_MATCH_1}")
+      else()
+        boost_message(VERBOSE "boost_test_jamfile: Jamfile line ignored: ${line}")
+        continue()
+      endif()
+
+      boost_test(PREFIX "${__PREFIX}" TYPE "${type}"
         SOURCES ${sources}
         LINK_LIBRARIES ${__LIBRARIES} ${__LINK_LIBRARIES}
         COMPILE_DEFINITIONS ${__COMPILE_DEFINITIONS}
         COMPILE_OPTIONS ${__COMPILE_OPTIONS}
         COMPILE_FEATURES ${__COMPILE_FEATURES}
       )
-
-    elseif(line MATCHES "^[ \t]*(${types})([ \t]|$)")
-
-      boost_message(VERBOSE "boost_test_jamfile: Jamfile line ignored: ${line}")
-
     endif()
 
   endforeach()

--- a/test/boost_test/Jamfile
+++ b/test/boost_test/Jamfile
@@ -1,4 +1,5 @@
 # Copyright 2018, 2019 Peter Dimov
+# Copyright 2023 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
@@ -13,9 +14,17 @@ compile-fail compile_fail.cpp ;
 link link.cpp ;
 link-fail link_fail.cpp ;
 run run.cpp ;
+# Multiple sources
+run run_multi.cpp run_multi_2.cpp ;
+# Similar but with semicolon on next line with B2 specifics (ignored in CMake)
+link run_multi_2.cpp run_multi.cpp
+  : : : <test-info>always_show_run_output ;
 run-fail run_fail.cpp
   : ;
 
+# Those should be skipped in CMake although valid B2
 run
   arguments.cpp :
   pumpkin ;
+run test_message.cpp : $(BOOST_ROOT)/subdir ;
+run run_multi.cpp <target-os>windows:non_existant.cpp ;

--- a/test/boost_test/run_multi.cpp
+++ b/test/boost_test/run_multi.cpp
@@ -1,0 +1,8 @@
+// Copyright 2023 Alexander Grund
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+int g()
+{
+    return 0;
+}

--- a/test/boost_test/run_multi_2.cpp
+++ b/test/boost_test/run_multi_2.cpp
@@ -1,0 +1,11 @@
+// Copyright 2023 Alexander Grund
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+//Maybe in a header:
+int g();
+
+int main()
+{
+    return g();
+}


### PR DESCRIPTION
Restrict that case to alpha-numeric (plus underscore) filenames with `.cpp` ending to avoid wrongly matching any other B2 syntax elements.

Closes #29 

Alternative implementation: Use 2 `if-MATCHES` each setting `sources` appropriately to avoid the nested RegEx. It makes sense to put the current last case (`elseif`) around those 2 so we can call `boost_message` and `continue` if neither of the 2 matches and call `boost_test` if either matched (i.e. I'd not duplicate the call to `boost_test`)