### PR TITLE
Add support for WORKING_DIRECTORY to boost_test

### DIFF
--- a/include/BoostTest.cmake
+++ b/include/BoostTest.cmake
@@ -9,6 +9,7 @@ set(BOOST_TEST_COMPILE_DEFINITIONS "")
 set(BOOST_TEST_COMPILE_OPTIONS "")
 set(BOOST_TEST_COMPILE_FEATURES "")
 set(BOOST_TEST_SOURCES "")
+set(BOOST_TEST_WORKING_DIRECTORY "")
 
 # Include guard
 
@@ -38,7 +39,7 @@ function(__boost_test_list_replace list what with)
 
 endfunction()
 
-# boost_test( [TYPE type] [PREFIX prefix] [NAME name] [IGNORE_TEST_GLOBALS]
+# boost_test( [TYPE type] [PREFIX prefix] [NAME name] [WORKING_DIRECTORY wd] [IGNORE_TEST_GLOBALS]
 #   SOURCES sources...
 #   ARGUMENTS args...
 #   LINK_LIBRARIES libs...
@@ -49,7 +50,7 @@ endfunction()
 
 function(boost_test)
 
-  cmake_parse_arguments(_ "IGNORE_TEST_GLOBALS" "TYPE;PREFIX;NAME" "SOURCES;ARGUMENTS;LIBRARIES;LINK_LIBRARIES;COMPILE_DEFINITIONS;COMPILE_OPTIONS;COMPILE_FEATURES" ${ARGN})
+  cmake_parse_arguments(_ "IGNORE_TEST_GLOBALS" "TYPE;PREFIX;NAME;WORKING_DIRECTORY" "SOURCES;ARGUMENTS;LIBRARIES;LINK_LIBRARIES;COMPILE_DEFINITIONS;COMPILE_OPTIONS;COMPILE_FEATURES" ${ARGN})
 
   if(NOT __TYPE)
     set(__TYPE run)
@@ -86,6 +87,7 @@ function(boost_test)
     set(BOOST_TEST_COMPILE_OPTIONS "")
     set(BOOST_TEST_COMPILE_FEATURES "")
     set(BOOST_TEST_SOURCES "")
+    set(BOOST_TEST_WORKING_DIRECTORY "")
 
   endif()
 
@@ -94,6 +96,9 @@ function(boost_test)
   list(APPEND BOOST_TEST_COMPILE_OPTIONS ${__COMPILE_OPTIONS})
   list(APPEND BOOST_TEST_COMPILE_FEATURES ${__COMPILE_FEATURES})
   list(APPEND BOOST_TEST_SOURCES ${__SOURCES})
+  if(__WORKING_DIRECTORY)
+    set(BOOST_TEST_WORKING_DIRECTORY ${__WORKING_DIRECTORY})
+  endif()
 
   if(MSVC)
 
@@ -210,6 +215,10 @@ function(boost_test)
 
     if(__TYPE STREQUAL "run-fail")
       set_tests_properties(${__TYPE}-${__NAME} PROPERTIES WILL_FAIL TRUE)
+    endif()
+    if(BOOST_TEST_WORKING_DIRECTORY)
+      set_target_properties(${__NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${BOOST_TEST_WORKING_DIRECTORY}")
+      set_tests_properties(${__TYPE}-${__NAME} PROPERTIES WORKING_DIRECTORY "${BOOST_TEST_WORKING_DIRECTORY}")
     endif()
 
   else()


### PR DESCRIPTION
Allow to set the working directory for the test and the VS debugger target.

I have a use case for that in Boost.Locale. Especially having the VS debugger set up properly is helpful and putting it here avoids the duplication.