### PR TITLE
Add optional deps into generated config

### DIFF
--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -315,7 +315,7 @@ function(boost_install_target)
         string(APPEND CONFIG_FILE_CONTENTS "  find_dependency(boost_${CMAKE_MATCH_1} ${__VERSION} EXACT)\n")
         string(APPEND CONFIG_FILE_CONTENTS "endif()\n")
 
-      elseif(dep MATCHES "^\\\$<TARGET_NAME_IF_EXISTS:Boost::(.*)>$")
+      elseif(dep MATCHES "^\\$<TARGET_NAME_IF_EXISTS:Boost::(.*)>$")
 
         string(APPEND CONFIG_FILE_CONTENTS "if(NOT boost_${CMAKE_MATCH_1}_FOUND)\n")
         string(APPEND CONFIG_FILE_CONTENTS "  find_package(boost_${CMAKE_MATCH_1} ${__VERSION} EXACT QUIET)\n")

--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -315,6 +315,12 @@ function(boost_install_target)
         string(APPEND CONFIG_FILE_CONTENTS "  find_dependency(boost_${CMAKE_MATCH_1} ${__VERSION} EXACT)\n")
         string(APPEND CONFIG_FILE_CONTENTS "endif()\n")
 
+      elseif(dep MATCHES "^\\\$<TARGET_NAME_IF_EXISTS:Boost::(.*)>$")
+
+        string(APPEND CONFIG_FILE_CONTENTS "if(NOT boost_${CMAKE_MATCH_1}_FOUND)\n")
+        string(APPEND CONFIG_FILE_CONTENTS "  find_package(boost_${CMAKE_MATCH_1} ${__VERSION} EXACT QUIET)\n")
+        string(APPEND CONFIG_FILE_CONTENTS "endif()\n")
+
       elseif(dep STREQUAL "Threads::Threads")
 
         string(APPEND CONFIG_FILE_CONTENTS "set(THREADS_PREFER_PTHREAD_FLAG ON)\n")


### PR DESCRIPTION
closes #52

This allows to declare optional inter boost dependencies via using 
`$<TARGET_NAME_IF_EXISTS:Boost::(.*)>`
instead of 
`Boost::(.*)`

Target visibility can be controlled by the user via the cmake variables:
`BOOST_INCLUDE_LIBRARIES/BOOST_EXCLUDE_LIBRARIES` on build.