### PR TITLE
Make zstd check agnostic to generator expressions and force CONFIG mode

### DIFF
--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -332,9 +332,9 @@ function(boost_install_target)
 
         string(APPEND CONFIG_FILE_CONTENTS "find_dependency(LibLZMA)\n")
 
-      elseif(dep STREQUAL "zstd::libzstd_shared" OR dep STREQUAL "zstd::libzstd_static")
+      elseif(dep MATCHES "zstd::libzstd_(shared|static)")
 
-        string(APPEND CONFIG_FILE_CONTENTS "find_dependency(zstd)\n")
+        string(APPEND CONFIG_FILE_CONTENTS "find_dependency(zstd CONFIG)\n")
 
       elseif(dep STREQUAL "MPI::MPI_CXX")
 


### PR DESCRIPTION
`zstd::libzstd_(shared|static)` targets have to be found via `CONFIG` mode

`STREQUAL` is not agnositic to the targets being wrapped within a generator expression like: 
`$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>`