### PR TITLE
Do export(...) to Boost targets

### DIFF
--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -301,7 +301,7 @@ function(boost_install_target)
     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
 
-  export(TARGETS ${LIB} NAMESPACE Boost:: FILE cmake/${LIB}-targets.cmake)
+  export(TARGETS ${LIB} NAMESPACE Boost:: FILE export/${LIB}-targets.cmake)
 
   if(MSVC)
     if(TYPE STREQUAL "SHARED_LIBRARY")

--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -301,6 +301,8 @@ function(boost_install_target)
     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
 
+  export(TARGETS ${LIB} NAMESPACE Boost:: FILE cmake/${LIB}-targets.cmake)
+
   if(MSVC)
     if(TYPE STREQUAL "SHARED_LIBRARY")
       install(FILES $<TARGET_PDB_FILE:${LIB}> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)


### PR DESCRIPTION
Hello,

We have a library that has a dependency on Boost. We use CMake's [`export(...)`](https://cmake.org/cmake/help/latest/command/export.html) on our library's targets, so that the targets are exported on the build tree (in addition to exporting them on installation, which is done when using `install(EXPORT ...)`).
This has worked when an installed Boost is used, since the Boost targets are introduced as IMPORTED targets, and thus CMake does not attempt to "export" them when we export our library. 

We are now trying to add an option for automatically fetching Boost using FetchContent, and thus installing Boost alongside our library. Now, since the Boost targets are not IMPORTED (but instead are "real", buildable targets), CMake will also try to "export" them when exporting our library, since our library is PUBLIC-ly linked to Boost targets.

We get the following errors when configuring our library:
```
CMake Error in CMakeLists.txt:
  export called with target "mylibrary_dependencies_boost" which requires target
  "boost_phoenix" that is not in any export set.
```

Adding this single line in BoostInstall.cmake will export the Boost targets inside Boost's build directory on configuration time, and allows us to use `export(...)` on our library, as all transitive dependencies are now also `export(...)`ed.
