### PR TITLE
update boost install to include natvis files

### DIFF
--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -214,6 +214,31 @@ function(__boost_install_update_include_directory lib incdir prop)
 
 endfunction()
 
+function(__boost_install_natvis lib)
+  if(lib MATCHES "^boost_(.*)$")
+
+    get_target_property(sources ${lib} INTERFACE_SOURCES)
+    foreach(src IN LISTS sources)
+
+      if(${src} MATCHES "^([A-Za-z0-9/_\-]+/${lib}\.natvis)|\\$<BUILD_INTERFACE:([A-Za-z0-9/_\-]+/${lib}\.natvis)>$")
+
+        if("${CMAKE_MATCH_1}" STREQUAL "")
+          set(natvis_file "${CMAKE_MATCH_2}")
+        else()
+          set(natvis_file "${CMAKE_MATCH_1}")
+        endif()
+
+        set_target_properties(${lib} PROPERTIES INTERFACE_SOURCES "$<BUILD_INTERFACE:${natvis_file}>;$<INSTALL_INTERFACE:${CMAKE_INSTALL_DATADIR}/${lib}-${PROJECT_VERSION}/${lib}.natvis>")
+        install(FILES "${natvis_file}" DESTINATION ${CMAKE_INSTALL_DATADIR}/${lib}-${PROJECT_VERSION})
+
+      endif()
+
+    endforeach()
+
+  endif()
+
+endfunction()
+
 # Installs a single target
 # boost_install_target(TARGET target VERSION version [HEADER_DIRECTORY directory])
 
@@ -316,6 +341,8 @@ function(boost_install_target)
     if(TYPE STREQUAL "STATIC_LIBRARY" AND NOT CMAKE_VERSION VERSION_LESS 3.15)
       install(FILES "$<TARGET_FILE_DIR:${LIB}>/$<TARGET_FILE_PREFIX:${LIB}>$<TARGET_FILE_BASE_NAME:${LIB}>.pdb" DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)
     endif()
+
+    __boost_install_natvis(${LIB})
   endif()
 
   install(EXPORT ${LIB}-targets DESTINATION "${CONFIG_INSTALL_DIR}" NAMESPACE Boost:: FILE ${LIB}-targets.cmake)


### PR DESCRIPTION
Probe the interfaces sources of a library target and manually patch the target's properties such that the natvis files are installed and probably linked against for downstream targets.

Partially closes https://github.com/boostorg/unordered/issues/307

For pure CMake builds, it seems like natvis files aren't loaded into the solution unless the end-target has the natvis file as a source file, which is only possible when they're carried transitively as an interface source.

This code enforces the largely existing idiom of using `extra/boost_<lib>.natvis` but we can maybe massage the regex to be more accommodating of other libraries like JSON and URL.