### PR TITLE
Reflect changes from https://github.com/boostorg/test/pull/445

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,13 @@ are given below.
   Defaults to ON under Windows when WinDbg support is autodetected and when
   `thread_local` is supported, otherwise OFF.
 
+### Test
+
+* `BOOST_TEST_HEADERS_ONLY`
+
+  When ON, installs only headers required for using the header-only variant of
+  the Unit Test Framework. Defaults to OFF.
+
 ### Thread
 
 * `BOOST_THREAD_THREADAPI`


### PR DESCRIPTION
This PR adds a Boost.Test-specific configuration variable, introduced in https://github.com/boostorg/test/pull/445, to `README.md`.