### PR TITLE
CMake: Show used CMake version in super-builds

### DIFF
--- a/include/BoostRoot.cmake
+++ b/include/BoostRoot.cmake
@@ -1,4 +1,5 @@
 # Copyright 2019-2023 Peter Dimov
+# Copyright 2025 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
@@ -13,7 +14,11 @@ include(BoostInstall)
 
 #
 
-boost_message(VERBOSE "Boost: using CMake ${CMAKE_VERSION}")
+if(CMAKE_SOURCE_DIR STREQUAL Boost_SOURCE_DIR)
+  boost_message(STATUS "Boost: using CMake ${CMAKE_VERSION}")
+else()
+  boost_message(VERBOSE "Boost: using CMake ${CMAKE_VERSION}")
+endif()
 
 #
 


### PR DESCRIPTION
In super-builds show the CMake version which is especially useful on CI to verify the used CMake and/or compare different jobs on failure.

Limited to the super build to not be too verbose when Boost is used via add_subdirectory or similar.
I kept the original call in the latter situation using VERBOSE