### PR TITLE
Test Boost configure with different CMake versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,6 @@ jobs:
             fi
           done
           # Libraries that don't declare their correct minimal required CMake version or where dependencies require higher version
-          version_greater_equal ${{matrix.cmake_version}} 3.10.0 || excluded+=("gil")
           version_greater_equal ${{matrix.cmake_version}} 3.12.0 || excluded+=("msm")
           version_greater_equal ${{matrix.cmake_version}} 3.14.0 || excluded+=("pfr" "mysql")  # mysql depends on pfr
           /tmp/cmake/bin/cmake --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,7 @@ jobs:
     strategy:
       matrix:
         enable_test: [ON, OFF]
+        cmake_version: [default, 3.5.0, 3.6.0, 3.8.0, 3.10.0, 3.13.0, 3.14.0, 3.16.0, 3.19.0, 3.31.0, 4.0.0, 4.1.0]
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -406,10 +407,11 @@ jobs:
           rm -rf tools/cmake/*
           cp -r $GITHUB_WORKSPACE/* tools/cmake
       - name: Configure each library independently
+        working-directory: ../boost-root
+        if: matrix.cmake_version == 'default'
         run: |
           failed_libs=""
           failed_outputs=()
-          cd ../boost-root
           for cml in libs/*/CMakeLists.txt; do
             lib=$(dirname "${cml#*libs/}")
             echo "====================================================================="
@@ -435,6 +437,33 @@ jobs:
             printf '%s\n' "${failed_outputs[@]}"
             exit 1
           fi
+
+      - name: Cache CMake
+        if: matrix.cmake_version != 'default'
+        id: cache-cmake
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cmake
+          key: ${{ runner.os }}-cmake-${{matrix.cmake_version}}
+
+      - name: Build CMake
+        if: matrix.cmake_version != 'default' && steps.cache-cmake.outputs.cache-hit != 'true'
+        run: |
+            version=${{matrix.cmake_version}}
+            filename="cmake-$version.tar.gz"
+            cd "$(mktemp -d)"
+            wget https://cmake.org/files/v${version%.*}/$filename
+            tar -xf $filename --strip-components=1
+            cmake -B __build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/cmake .
+            cmake --build __build -- -j 3
+            cmake --build __build --target install
+
+      - name: Configure Boost with CMake ${{matrix.cmake_version}}
+        working-directory: ../boost-root
+        if: matrix.cmake_version != 'default'
+        run: |
+          /tmp/cmake/bin/cmake --version
+          /tmp/cmake/bin/cmake -DBUILD_TESTING=${{matrix.enable_test}} -B "__build_cmake-$version" .
 
   BoostTest:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,13 +386,9 @@ jobs:
     strategy:
       matrix:
         enable_test: [ON, OFF]
-        cmake_version: [default, 3.5.0, 3.6.0, 3.8.0, 3.9.0, 3.10.0, 3.13.0, 3.14.0, 3.16.0, 3.19.0, 3.31.0, 4.0.0, 4.1.0]
+        cmake_version: [default, 3.8.0, 3.9.0, 3.10.0, 3.11.0, 3.12.0, 3.13.0, 3.14.0, 3.16.0, 3.19.0, 3.31.0, 4.0.0, 4.1.0]
         exclude:
           # BoostTestJamfile requires CMake 3.9
-          - cmake_version: 3.5.0
-            enable_test: ON
-          - cmake_version: 3.6.0
-            enable_test: ON
           - cmake_version: 3.8.0
             enable_test: ON
       fail-fast: false
@@ -493,7 +489,6 @@ jobs:
             fi
           done
           # Libraries that don't declare their correct minimal required CMake version or where dependencies require higher version
-          version_greater_equal ${{matrix.cmake_version}} 3.8.0  || excluded+=("static_string")
           version_greater_equal ${{matrix.cmake_version}} 3.10.0 || excluded+=("gil")
           version_greater_equal ${{matrix.cmake_version}} 3.12.0 || excluded+=("msm")
           version_greater_equal ${{matrix.cmake_version}} 3.14.0 || excluded+=("pfr" "mysql")  # mysql depends on pfr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,10 @@ jobs:
           path: /tmp/cmake
           key: ${{ runner.os }}-cmake-${{matrix.cmake_version}}
 
+      - name: Install CMake dependencies
+        if: matrix.cmake_version != 'default'
+        run: sudo apt-get -o Acquire::Retries=3 -y -q --no-install-suggests --no-install-recommends install curl libcurl4-openssl-dev libarchive-dev
+
       - name: Build CMake
         if: matrix.cmake_version != 'default' && steps.cache-cmake.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,15 @@ jobs:
     strategy:
       matrix:
         enable_test: [ON, OFF]
-        cmake_version: [default, 3.5.0, 3.6.0, 3.8.0, 3.10.0, 3.13.0, 3.14.0, 3.16.0, 3.19.0, 3.31.0, 4.0.0, 4.1.0]
+        cmake_version: [default, 3.5.0, 3.6.0, 3.8.0, 3.9.0, 3.10.0, 3.13.0, 3.14.0, 3.16.0, 3.19.0, 3.31.0, 4.0.0, 4.1.0]
+        exclude:
+          # BoostTestJamfile requires CMake 3.9
+          - cmake_version: 3.5.0
+            enable_test: ON
+          - cmake_version: 3.6.0
+            enable_test: ON
+          - cmake_version: 3.8.0
+            enable_test: ON
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -474,8 +482,17 @@ jobs:
         working-directory: ../boost-root
         if: matrix.cmake_version != 'default'
         run: |
+          version_greater_equal() { printf '%s\n' "$2" "$1" | sort --check=quiet --version-sort; }
+          excluded=()
+          version_greater_equal ${{matrix.cmake_version}} 3.7.0  || excluded+=("outcome")
+          version_greater_equal ${{matrix.cmake_version}} 3.8.0  || excluded+=("asio" "atomic" "beast" "bind" "bloom" "callable_traits" "charconv" "chrono" "compat" "container_hash" "contract" "crc" "date_time" "endian" "fiber" "filesystem" "format" "function" "geometry" "gil" "graph" "hana" "hash2" "heap" "hof" "iostreams" "json" "lambda2" "lockfree" "log" "mqtt5" "mysql" "numeric/ublas" "process" "program_options" "property_tree" "random" "ratio" "redis" "safe_numerics" "serialization" "smart_ptr" "static_string" "stl_interfaces" "system" "test" "thread" "type_erasure" "typeof" "unordered" "url" "uuid" "variant2" "wave" "yap")
+          version_greater_equal ${{matrix.cmake_version}} 3.9.0  || excluded+=("hana" "nowide")
+          version_greater_equal ${{matrix.cmake_version}} 3.10.0 || excluded+=("gil" "sort")
+          version_greater_equal ${{matrix.cmake_version}} 3.11.0 || excluded+=("locale")
+          version_greater_equal ${{matrix.cmake_version}} 3.12.0 || excluded+=("cobalt" "histogram" "msm")
+          version_greater_equal ${{matrix.cmake_version}} 3.14.0 || excluded+=("parser" "python" "pfr" "mysql")  # mysql depends on pfr
           /tmp/cmake/bin/cmake --version
-          /tmp/cmake/bin/cmake -DBUILD_TESTING=${{matrix.enable_test}} -B "__build_cmake-$version" .
+          /tmp/cmake/bin/cmake -DBUILD_TESTING=${{matrix.enable_test}} -DBOOST_EXCLUDE_LIBRARIES="$(IFS=';'; echo "${excluded[*]}")" -B "__build_cmake-$version" .
 
   BoostTest:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,13 +484,19 @@ jobs:
         run: |
           version_greater_equal() { printf '%s\n' "$2" "$1" | sort --check=quiet --version-sort; }
           excluded=()
-          version_greater_equal ${{matrix.cmake_version}} 3.7.0  || excluded+=("outcome")
-          version_greater_equal ${{matrix.cmake_version}} 3.8.0  || excluded+=("asio" "atomic" "beast" "bind" "bloom" "callable_traits" "charconv" "chrono" "compat" "container_hash" "contract" "crc" "date_time" "endian" "fiber" "filesystem" "format" "function" "geometry" "gil" "graph" "hana" "hash2" "heap" "hof" "iostreams" "json" "lambda2" "lockfree" "log" "mqtt5" "mysql" "numeric/ublas" "process" "program_options" "property_tree" "random" "ratio" "redis" "safe_numerics" "serialization" "smart_ptr" "static_string" "stl_interfaces" "system" "test" "thread" "type_erasure" "typeof" "unordered" "url" "uuid" "variant2" "wave" "yap")
-          version_greater_equal ${{matrix.cmake_version}} 3.9.0  || excluded+=("hana" "nowide")
-          version_greater_equal ${{matrix.cmake_version}} 3.10.0 || excluded+=("gil" "sort")
-          version_greater_equal ${{matrix.cmake_version}} 3.11.0 || excluded+=("locale")
-          version_greater_equal ${{matrix.cmake_version}} 3.12.0 || excluded+=("cobalt" "histogram" "msm")
-          version_greater_equal ${{matrix.cmake_version}} 3.14.0 || excluded+=("parser" "python" "pfr" "mysql")  # mysql depends on pfr
+          for cml in "$PWD"/libs/*/CMakeLists.txt "$PWD"/libs/numeric/*/CMakeLists.txt; do
+            lib=$(dirname "${cml#*libs/}")
+            if minimal_cmake_version=$(grep "cmake_minimum_required" "$cml" | grep -Eo '[0-9]\.[0-9]+' | head -1); then
+              version_greater_equal ${{matrix.cmake_version}} "$minimal_cmake_version" || excluded+=("$lib")
+            else
+              echo "Minimum required CMake version not found in $cml for library $lib"
+            fi
+          done
+          # Libraries that don't declare their correct minimal required CMake version or where dependencies require higher version
+          version_greater_equal ${{matrix.cmake_version}} 3.8.0  || excluded+=("static_string")
+          version_greater_equal ${{matrix.cmake_version}} 3.10.0 || excluded+=("gil")
+          version_greater_equal ${{matrix.cmake_version}} 3.12.0 || excluded+=("msm")
+          version_greater_equal ${{matrix.cmake_version}} 3.14.0 || excluded+=("pfr" "mysql")  # mysql depends on pfr
           /tmp/cmake/bin/cmake --version
           /tmp/cmake/bin/cmake -DBUILD_TESTING=${{matrix.enable_test}} -DBOOST_EXCLUDE_LIBRARIES="$(IFS=';'; echo "${excluded[*]}")" -B "__build_cmake-$version" .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,7 +454,15 @@ jobs:
             cd "$(mktemp -d)"
             wget https://cmake.org/files/v${version%.*}/$filename
             tar -xf $filename --strip-components=1
-            cmake -B __build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/cmake .
+            flags=(
+              "-DCMAKE_BUILD_TYPE=Release"
+              "-DCMAKE_INSTALL_PREFIX=/tmp/cmake"
+              "-B" "__build"
+              "-Wno-dev"  # Make configuring more silent
+              "-DCMAKE_USE_SYSTEM_CURL=1"  # Avoid failures caused by newer (system) OpenSSL in CMake < 3.10
+              "-DCMAKE_CXX_FLAGS='-include cstdint -include limits'"  # Fix missing includes in CMake < 3.10
+            )
+            cmake "${flags[@]}" .
             cmake --build __build -- -j 3
             cmake --build __build --target install
 


### PR DESCRIPTION
As [previously discussed](https://github.com/boostorg/cmake/pull/90#issuecomment-3344070496) this adds CI jobs that configure the Boost tree with various CMake versions.

For that the CMake source is downloaded and compiled, then cached for future jobs.   
Using existing binary downloads failed due to e.g. updated OpenSSL libraries installed on the system. For a similar reason libcurl-dev is installed to be used by CMake instead of it building its bundled version of cURL which is incompatible with the system OpenSSL in some CMake versions.


Individual Boost libraries require different minimal CMake versions. That should be declared in their CMakeLists correctly. The `cmake_minimum_required` line is used to determine which libraries to exclude for the currently tested CMake version.   
Some depend on libraries requiring a higher CMake version than itself or fail to declare their required CMake version, hence a manual list is maintained in addition to that.

The list of tested CMake versions is based on features selected depending on the CMake version:
- 3.8 as the minimal required one, see https://github.com/boostorg/boost/pull/1088
- 3.9 as the one where BoostTestJamfile works
- 3.10 checked for by BoostInstall.cmake
- 3.13 As the first to support automatic installation via BoostInstall
- 3.31 as the last 3.x version
- 4.0 as the first 4.x version
- 4.1 as the current version
- Some versions inbetween based on usage by Boost libraries and known prior failures (e.g. 3.11 allows whitelisted properties on INTERFACE libraries, others fail as seen with 3.16 on Windows, 3.19 lifted the restriction)