### PR TITLE
Feat: Add support to install FILE_SET too

### DIFF
--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -337,21 +337,22 @@ function(boost_install_target)
     string(APPEND CONFIG_INSTALL_DIR "-static")
   endif()
 
+  set(__INSTALL_CXX_MODULES)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
     get_target_property(INTERFACE_CXX_MODULE_SETS ${LIB} INTERFACE_CXX_MODULE_SETS)
     if(INTERFACE_CXX_MODULE_SETS)
       boost_message(DEBUG "boost_install_target: '${__TARGET}' has INTERFACE_CXX_MODULE_SETS=${INTERFACE_CXX_MODULE_SETS}")
-      set(__INSTALL_CXX_MODULES FILE_SET ${INTERFACE_CXX_MODULE_SETS} DESTINATION ${CONFIG_INSTALL_DIR})
-      set(__INSTALL_CXX_MODULES_BMI CXX_MODULES_BMI DESTINATION ${CONFIG_INSTALL_DIR}/bmi-${CMAKE_CXX_COMPILER_ID}_$<CONFIG>)
-      set(__EXPORT_CXX_MODULES_DIRECTORY CXX_MODULES_DIRECTORY .)
+      set(extrainstalldir "${CMAKE_INSTALL_DATADIR}/boost-${__VERSION}/${LIB}")
+      set(__INSTALL_CXX_MODULES FILE_SET ${INTERFACE_CXX_MODULE_SETS} DESTINATION ${extrainstalldir})
     endif()
   endif()
 
+  set(__INSTALL_HEADER_SETS)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
     get_target_property(INTERFACE_HEADER_SETS ${LIB} INTERFACE_HEADER_SETS)
     if(INTERFACE_HEADER_SETS)
       boost_message(DEBUG "boost_install_target: '${__TARGET}' has INTERFACE_HEADER_SETS=${INTERFACE_HEADER_SETS}")
-      set(__INSTALL_HEADER_SETS FILE_SET ${INTERFACE_HEADER_SETS})
+      set(__INSTALL_HEADER_SETS FILE_SET ${INTERFACE_HEADER_SETS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/boost-${__VERSION}")
     endif()
   endif()
 
@@ -362,8 +363,8 @@ function(boost_install_target)
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     PRIVATE_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    # NOTE: explicit needed if used starting with cmake v3.28
-    # XXX FILE_SET CXX_MODULES DESTINATION ${CONFIG_INSTALL_DIR}
+    # explicit needed if used starting with cmake v3.28
+    # XXX FILE_SET CXX_MODULES DESTINATION "${CMAKE_INSTALL_DATADIR}"
     ${__INSTALL_CXX_MODULES}
     # Any module files from C++ modules from PUBLIC sources in a file set of type CXX_MODULES will be installed to the given DESTINATION.
     # TODO(CK) ${__INSTALL_CXX_MODULES_BMI}
@@ -390,7 +391,7 @@ function(boost_install_target)
   endif()
 
   install(EXPORT ${LIB}-targets DESTINATION "${CONFIG_INSTALL_DIR}" NAMESPACE Boost:: FILE ${LIB}-targets.cmake
-      # TODO(CK) ${__EXPORT_CXX_MODULES_DIRECTORY}
+    CXX_MODULES_DIRECTORY .
   )
 
   set_target_properties(${LIB} PROPERTIES _boost_is_installed ON)
@@ -618,6 +619,7 @@ function(boost_install)
 
   endif()
 
+  set(extrainstalldir)
   if(__EXTRA_DIRECTORY AND NOT BOOST_SKIP_INSTALL_RULES AND NOT CMAKE_SKIP_INSTALL_RULES)
 
     # Extract the library name from the path, one component up from the extra directory

--- a/include/BoostInstall.cmake
+++ b/include/BoostInstall.cmake
@@ -338,12 +338,14 @@ function(boost_install_target)
   endif()
 
   set(__INSTALL_CXX_MODULES)
+  set(__EXPORT_CXX_MODULES_CONFIG_FILES)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
     get_target_property(INTERFACE_CXX_MODULE_SETS ${LIB} INTERFACE_CXX_MODULE_SETS)
     if(INTERFACE_CXX_MODULE_SETS)
       boost_message(DEBUG "boost_install_target: '${__TARGET}' has INTERFACE_CXX_MODULE_SETS=${INTERFACE_CXX_MODULE_SETS}")
       set(extrainstalldir "${CMAKE_INSTALL_DATADIR}/boost-${__VERSION}/${LIB}")
       set(__INSTALL_CXX_MODULES FILE_SET ${INTERFACE_CXX_MODULE_SETS} DESTINATION ${extrainstalldir})
+      set(__EXPORT_CXX_MODULES_CONFIG_FILES CXX_MODULES_DIRECTORY .)
     endif()
   endif()
 
@@ -363,13 +365,13 @@ function(boost_install_target)
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     PRIVATE_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    # explicit needed if used starting with cmake v3.28
-    # XXX FILE_SET CXX_MODULES DESTINATION "${CMAKE_INSTALL_DATADIR}"
+    # NOTE: explicit needed if used starting with cmake v3.28!
+    # optional install: FILE_SET CXX_MODULES DESTINATION "${CMAKE_INSTALL_DATADIR}"
     ${__INSTALL_CXX_MODULES}
-    # Any module files from C++ modules from PUBLIC sources in a file set of type CXX_MODULES will be installed to the given DESTINATION.
-    # TODO(CK) ${__INSTALL_CXX_MODULES_BMI}
-    # NOTE: explicit needed if used starting with cmake v3.23
-    # XXX FILE_SET HEADERS
+    # NOTE: explicit needed if used starting with cmake v3.23!
+    # Any module files from C++ modules from PUBLIC sources in a file set
+    # of type CXX_MODULES will be installed to the given DESTINATION.
+    # optional install: FILE_SET HEADERS
     ${__INSTALL_HEADER_SETS}
   )
 
@@ -391,7 +393,9 @@ function(boost_install_target)
   endif()
 
   install(EXPORT ${LIB}-targets DESTINATION "${CONFIG_INSTALL_DIR}" NAMESPACE Boost:: FILE ${LIB}-targets.cmake
-    CXX_MODULES_DIRECTORY .
+    # NOTE: explicit needed if used starting with cmake v3.28!
+    # optional install config packages for: FILE_SET CXX_MODULES
+    ${__EXPORT_CXX_MODULES_CONFIG_FILES}
   )
 
   set_target_properties(${LIB} PROPERTIES _boost_is_installed ON)

--- a/include/BoostRoot.cmake
+++ b/include/BoostRoot.cmake
@@ -303,6 +303,9 @@ macro(__boost_add_header_only lib)
 
 endmacro()
 
+# C++20 modules
+option(BOOST_USE_MODULES "Build Boost as a collection of C++20 modules (unstable)" OFF)
+
 #
 
 file(GLOB __boost_libraries RELATIVE "${BOOST_SUPERPROJECT_SOURCE_DIR}/libs" "${BOOST_SUPERPROJECT_SOURCE_DIR}/libs/*/CMakeLists.txt" "${BOOST_SUPERPROJECT_SOURCE_DIR}/libs/numeric/*/CMakeLists.txt")


### PR DESCRIPTION
with `any, type_info, pfr, conversion, lexical_cast, stacktrace` there are at leaset 6 boost libs preparing **CXX_MODULES**

This patch enable to install it too

see my work and tests ant https://github.com/ClausKlein/boost-cmake/pull/13